### PR TITLE
Mark as compatible with KSP 1.12.3

### DIFF
--- a/GameData/MagiCore/MagiCore.version
+++ b/GameData/MagiCore/MagiCore.version
@@ -15,7 +15,7 @@
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 12,
-    "PATCH": 2
+    "PATCH": 3
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,

--- a/MagiCore.version
+++ b/MagiCore.version
@@ -15,7 +15,7 @@
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 12,
-    "PATCH": 2
+    "PATCH": 3
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,


### PR DESCRIPTION
This mod has been tested to work just fine on KSP 1.12.3. This PR aims to change the CKAN metadata to reflect this.